### PR TITLE
A few minor enhancements and corner cases

### DIFF
--- a/populations/bbh_models.py
+++ b/populations/bbh_models.py
@@ -38,7 +38,7 @@ def get_models(dirpath, params, spin_distr=None, weighting=False, **kwargs):
     # --- Read in the models, parse the inference parameters
     if VERBOSE:
         print("\nReading models and applying transformations...\n")
-    model_files = [dirpath + f for f in os.listdir(dirpath)]
+    model_files = [os.path.join(dirpath, f) for f in os.listdir(dirpath)]
     channels = list(h5py.File(model_files[0]).keys())
 
     # all models should be saved as hdf files living at dirpath with the channels as keys
@@ -47,7 +47,7 @@ def get_models(dirpath, params, spin_distr=None, weighting=False, **kwargs):
         models[mdl_name] = {}
         for channel in channels:
             inference_params = pd.DataFrame()
-            df = pd.read_hdf(dirpath + mdl_file, key=channel)
+            df = pd.read_hdf(os.path.join(dirpath, mdl_file), key=channel)
 
             # check if params in the dataframe, otherwise perform transformations
             for param in params:

--- a/populations/msplot.py
+++ b/populations/msplot.py
@@ -73,7 +73,10 @@ def plot_1D_kdemodels(kde_models, params, obsdata, model0, name=None, plot_obs=F
 
         # loop over all parameters...
         for pidx, param in enumerate(params):
-            ax = axs[idx,pidx]
+            if axs.ndim == 1:
+                ax = axs[idx]
+            else:
+                ax = axs[idx,pidx]
 
             pdf_max = 0
             # loop over all channels...


### PR DESCRIPTION
 - A single parameter run would fail to plot because the plotting assumed there were more than one parameters
 - the data path required a trailing slash, so use `os.path.join` instead