### PR TITLE
Remove hardcoded channel and hyperparameter structure from flow classes

### DIFF
--- a/model_select
+++ b/model_select
@@ -117,7 +117,7 @@ if use_flows==True:
     if verbose:
         print("\nReading models, applying transformations, and initializing underlying Normalising Flow models...\n")
     model_names, pop_models = bbh_models.get_models(args.file_path, args.channels, args.params, use_flows, flow_path=args.flow_model_filename,\
-            sensitivity=args.sensitivity, device=args.device, detectable=False)
+            sensitivity=args.sensitivity, detectable=False)
 else:
     # Construct both "underlying" KDE models (anything that has Pdet>0) and "detectable" KDE models
     # `normalize` argument normalizes KDEs on unit cube
@@ -356,7 +356,7 @@ if use_flows==True:
                 pop_models[channel].wandb_init(int(args.epochs[i]))
             else:
                 pop_models[channel].train(int(args.no_trans[i]), int(args.spline_bins[i]), int(args.no_neurons[i]), lr[i], \
-                    int(args.epochs[i]), args.batch_no, args.flow_model_filename, args.testCEmodel, use_wandb)
+                    int(args.epochs[i]), args.batch_no, args.flow_model_filename, devicee=args.device)
         else:
             pop_models[channel].load_model(args.flow_model_filename, device=args.device)
 else:

--- a/populations/Pop_Flows.py
+++ b/populations/Pop_Flows.py
@@ -296,7 +296,13 @@ class FlowModel(Model):
         #map samples back from logit space
         samps = np.zeros(np.shape(logit_samps))
         for pidx, param in enumerate(self.param_dict):
-            samps[:,pidx] = self.expistic(logit_samps[:,pidx], self.param_dict[param]['logit_max'], self.param_dict[param]['max'])
+            if self.param_dict[param]['transf'] == 'logit':
+                samps[:,pidx] = self.expistic(logit_samps[:,pidx], self.param_dict[param]['logit_max'], self.param_dict[param]['max'])
+            elif self.param_dict[param]['transf'] == 'tanh':
+                samps[:,pidx] = np.tanh(logit_samps[:,pidx])
+            else:
+                print(f'No transformation type specified for {param} dimension, attempting expistic transform')
+                samps[:,pidx] = self.expistic(logit_samps[:,pidx], self.param_dict[param]['logit_max'], self.param_dict[param]['max'])
 
         return samps
 
@@ -414,7 +420,13 @@ class FlowModel(Model):
 
         #compute logistic mappings of data
         for pidx, param in enumerate(self.param_dict):
-            mapped_data[:,:,pidx] = self.logistic(data[:,:,pidx], False, self.param_dict[param]['logit_max'], self.param_dict[param]['max'])
+            if self.param_dict[param]['transf'] == 'logit':
+                mapped_data[:,:,pidx] = self.logistic(data[:,:,pidx], False, self.param_dict[param]['logit_max'], self.param_dict[param]['max'])
+            elif self.param_dict[param]['transf'] == 'tanh':
+                mapped_data[:,:,pidx] = np.arctanh(data[:,:,pidx])
+            else:
+                print(f'No transformation type specified for {param} dimension, attempting logistic transform')
+                mapped_data[:,:,pidx] = self.logistic(data[:,:,pidx], False, self.param_dict[param]['logit_max'], self.param_dict[param]['max'])
 
         return mapped_data
 

--- a/populations/Pop_Flows.py
+++ b/populations/Pop_Flows.py
@@ -11,6 +11,7 @@ import pdb
 import time
 import wandb
 import json
+from itertools import product
 
 import numpy as np
 import scipy as sp
@@ -22,6 +23,7 @@ from scipy.special import expit
 from sklearn.model_selection import train_test_split
 from .utils.selection_effects import projection_factor_Dominik2015_interp, _PSD_defaults
 from .utils.flow import NFlow
+
 
 from astropy import cosmology
 from astropy.cosmology import z_at_value
@@ -51,7 +53,7 @@ class Model(object):
 
 class FlowModel(Model):
     @staticmethod
-    def from_samples(channel, samples, params, channel_hyperparams, smdl_indxs_combos, flow_path, sensitivity=None, device='cpu'):
+    def from_samples(channel, samples, param_dict, channel_hyperparams, smdl_indxs_combos, flow_path, sensitivity=None):
         """
         Generate a Flow model instance from `samples`, where `params` are series in the `samples` dataframe. 
         
@@ -75,8 +77,6 @@ class FlowModel(Model):
             Desired detector sensitivity consistent with the string following the `pdet` and `snropt` columns in the population dataframes.
             Used to construct a detection-weighted population model, as well as for drawing samples from the underlying population
             to calculate the detection efficiency
-        deivce : str
-            Device on which to run the flow. Either is 'cpu', otherwise choose 'cuda:X' where X is the GPU slot.
         
         Returns
         ----------
@@ -84,14 +84,14 @@ class FlowModel(Model):
         """
 
         #set model keys for specified training data
-        self.model_keys = smdl_indxs_combos
+        model_keys = smdl_indxs_combos
 
         #initialise dictionaries of alpha, cosmo_weights, pdet, optimal_snrs, and combined_weights for each submodel
         alpha = dict.fromkeys(samples.keys())
         cosmo_weights= dict.fromkeys(samples.keys())
         combined_weights= dict.fromkeys(samples.keys())
 
-        for model_idxs in self.model_keys:
+        for model_idxs in model_keys:
             #grab samples for each submodel according to key in samples dict
             if model_idxs.ndim > 0:
                 dict_key = tuple(model_idxs)
@@ -127,10 +127,10 @@ class FlowModel(Model):
                 combined_weights[dict_key] = (cosmo_weights[dict_key] / np.sum(cosmo_weights[dict_key]))
             else:
                 combined_weights[dict_key] = np.ones(len(sbml_samps))
-        return FlowModel(channel, samples, params, flow_path, channel_hyperparams, combined_weights, alpha, device=device)
+        return FlowModel(channel, samples, param_dict, flow_path, channel_hyperparams, combined_weights, alpha, model_keys)
 
 
-    def __init__(self, channel, samples, param_dict, flow_path, channel_hyperparams, combined_weights, alpha, device):
+    def __init__(self, channel, samples, param_dict, flow_path, channel_hyperparams, combined_weights, alpha, model_keys):
         """
         Initialisation for FlowModel object. Sets self.flow as instance of Nflow class, of which FlowModel is wrapper of that object.
 
@@ -145,10 +145,6 @@ class FlowModel(Model):
             subset of [mchirp, q, chieff, z]
         flow_path : str
             directory of the flow models to load network config from if config file exists
-        sensitivity : str
-            Desired detector sensitivity consistent with the string following the `pdet` and `snropt` columns in the population dataframes.
-            Used to construct a detection-weighted population model, as well as for drawing samples from the underlying population
-            to calculate the detection efficiency
         deivce : str
             Device on which to run the flow. default is 'cpu', otherwise choose 'cuda:X' where X is the GPU slot.
         """
@@ -159,24 +155,16 @@ class FlowModel(Model):
 
         #want this to be structured {'mchirp':{'bounds':(0,100.), 'max':(100.)}, 'q':{...}, 'chieff:{...}}
         self.param_dict = param_dict
-        #i think we don't need the below: instead we can loop thru param_dict
-        #self.params = self.param_dict["keys"]
-        #self.param_bounds = self.param_dict["bounds"]
 
-        #initialises list of population hyperparameters from model keys
-        self.hyperparam_models = channel_hyperparams["keys"]
-        self.hp_vals = channel_hyperparams["values"]
-
-        #retrieve hyperparameter values from model keys
-        #TO CHANGE - NEEDS GENERALISING, currently assumes values are last 2 digits of model keys /10
-        #self.hp_vals = []
-        """for d, dim in enumerate(self.hyperparam_models):
-            self.hp_vals.append([])
-            for smdl in dim:
-                self.hp_vals[d].append(float(smdl[-2:])/10)"""
+        #initialises list of population hyperparameters from hyperparameter dictionary
+        self.hyperparam_models = []
+        self.hp_vals = []
+        for hp in channel_hyperparams:
+            self.hyperparam_models.append(channel_hyperparams[hp]["keys"])
+            self.hp_vals.append(channel_hyperparams[hp]["vals"])
         
         #number of binary parameters
-        self.no_params = np.shape(params)[0]
+        self.no_params = len(param_dict.keys())
         #dimensionailty of non-branching ratio hyperparameters
         self.conditionals = len(self.hyperparam_models)
 
@@ -185,6 +173,7 @@ class FlowModel(Model):
         self.alpha = alpha
 
         #initialise the channel of this flow and how many training submodels exist for this channel
+        self.model_keys = model_keys
         self.total_smdls = len(model_keys)
 
 
@@ -247,22 +236,29 @@ class FlowModel(Model):
 
         #moves binary parameter samples and weights from dictionaries into array
         for i, model_idxs in enumerate(self.model_keys):
-            models[int(cumulsize[i-1]):int(cumulsize[i])]=np.reshape(np.asarray(self.samples[model_idxs][params])[weights_idxs[i]],(-1,len(params)))
-            weights[int(cumulsize[i-1]):int(cumulsize[i])]=np.asarray(self.combined_weights[model_idxs])[weights_idxs[i]]
+            if model_idxs.ndim > 0:
+                dict_key = tuple(model_idxs)
+            else:
+                dict_key = model_idxs
+            models[int(cumulsize[i-1]):int(cumulsize[i])]=np.reshape(np.asarray(self.samples[dict_key][self.param_dict.keys()])[weights_idxs[i]],(-1,len(self.param_dict.keys())))
+            weights[int(cumulsize[i-1]):int(cumulsize[i])]=np.asarray(self.combined_weights[dict_key])[weights_idxs[i]]
 
         models_stack = np.copy(models)
-
         #map samples with logistic mapping before dividing into training and validation data
-
-        mappings = dict(fromkeys(params,{'logit_max', 'max'})
-
         for pidx, param in enumerate(self.param_dict):
-            models_stack[:,pidx], mappings['logit_max'], mappings['max'] = self.logistic(models_stack[:,pidx],wholedataset=True, \
-                rescale_max=self.param_dict[param]['bounds'][1])
+            if self.param_dict[param]['transf'] == 'logit':
+                models_stack[:,pidx], self.param_dict[param]['logit_max'], self.param_dict[param]['max'] = self.logistic(models_stack[:,pidx],\
+                    wholedataset=True, rescale_max=self.param_dict[param]['bounds'][1])
+            elif self.param_dict[param]['transf'] == 'tanh':
+                models_stack[:,pidx] = np.arctanh(models_stack[:,pidx])
+            else:
+                print(f'No transformation type specified for {param} dimension, attempting logistic transform')
+                models_stack[:,pidx], self.param_dict[param]['logit_max'], self.param_dict[param]['max'] = self.logistic(models_stack[:,pidx],\
+                    wholedataset=True, rescale_max=self.param_dict[param]['bounds'][1])
             
         #repeat subpopulation hyperparameter values Nsamps times for each subpopulation
-        hp_combos = np.squeeze(list(product(*self.hps)))
-        hps_stack = np.repeat(training_hps, (model_size).astype(int), axis=0)
+        hp_combos = np.squeeze(list(product(*self.hp_vals)))
+        hps_stack = np.repeat(hp_combos, (model_size).astype(int), axis=0)
 
         #reshape conditionals and weights
         hps_stack = np.reshape(hps_stack,(-1,self.conditionals))
@@ -271,86 +267,12 @@ class FlowModel(Model):
         #split the training data, conditional data, and sample weights into training and validation sets
         train_models_stack, validation_models_stack, train_weights, validation_weights, training_hps_stack, validation_hps_stack = \
                 train_test_split(models_stack, weights, hps_stack, shuffle=True, train_size=0.8)
-            
-        """else:
-            #CE channel with alpha_CE parameter
-
-            #tile list of chi_bs and alpha_CEs into liost for each training sub-population
-            chi_b_alpha_pairs= np.zeros((self.total_smdls, 2))
-            chi_b_alpha_pairs[:,0] = np.repeat(self.hps[0],np.shape(self.hps[1])[0])
-            chi_b_alpha_pairs[:,1] = np.tile(np.log(self.hps[1]), np.shape(self.hps[0])[0])
-
-            #initialise arrays for model size
-            model_size = np.zeros((4,5))
-            cumulsize = np.zeros(self.total_smdls)
-            weights_idxs = []
-
-            #meaure no samples in each population, and the cumulative samples in each population used for training
-            i=0
-            for chib_id in range(4):
-                for alpha_id in range(5):
-                    if testCEsmdl:
-                        if [chib_id, alpha_id] == test_model_id:
-                            continue
-                    weights_temp=np.asarray(self.combined_weights[(chib_id, alpha_id)])
-                    weights_idxs.append(np.argwhere((weights_temp) > np.finfo(np.float32).tiny))
-                    model_size[chib_id, alpha_id] = np.shape(weights_idxs[i])[0]
-                    cumulsize[i] = np.sum(model_size)
-                    i+=1
-
-            self.no_binaries = int(cumulsize[-1])
-            models = np.zeros((self.no_binaries, self.no_params))
-            weights = np.zeros((self.no_binaries,1))
-            cumulsize = np.append(cumulsize, 0)
-
-            #put samples from each model into array of shape [no_samples in channel, no params]
-            #and weights into array [no_samples in channel, 1]
-            i=0
-            for chib_id in range(4):
-                for alpha_id in range(5):
-                    if testCEsmdl:
-                        if [chib_id, alpha_id] == test_model_id:
-                            continue
-                    models[int(cumulsize[i-1]):int(cumulsize[i])]=np.reshape(np.asarray(samples[(chib_id, alpha_id)][params])[weights_idxs[i]],(-1,len(params)))
-                    weights[int(cumulsize[i-1]):int(cumulsize[i])]=np.reshape(np.asarray(self.combined_weights[(chib_id, alpha_id)])[weights_idxs[i]],(-1,1))
-                    i+=1
-
-            #repeat the pairs of [chi_b, alphaCE] for the number of samples in the training samples
-            all_chi_b_alphas = np.repeat(chi_b_alpha_pairs, (flat_model_size).astype(int), axis=0)
-
-
-            #scale parameters with logistic mapping, only for full range of parameters
-            models_stack = np.copy(models)
-
-            #chirp mass original range 0 to inf
-            models_stack[:,0], max_logit_mchirp, max_mchirp = self.logistic(models_stack[:,0], wholedataset=True, \
-                rescale_max=self.param_bounds[0][1])
-
-            #mass ratio - original range 0 to 1
-            models_stack[:,1], max_logit_q, max_q = self.logistic(models_stack[:,1], wholedataset=True, \
-                rescale_max=self.param_bounds[1][1])
-
-            #chieff - original range -1 to +1
-            models_stack[:,2] = np.arctanh(models_stack[:,2])
-
-            #redshift - original range 0 to inf
-            models_stack[:,3], max_logit_z, max_z = self.logistic(models_stack[:,3],wholedataset=True, \
-                rescale_max=self.param_bounds[3][1])
-
-            weights = np.reshape(weights,(-1,1))
-            train_models_stack, validation_models_stack, train_weights, validation_weights, training_hps_stack, validation_hps_stack = \
-                    train_test_split(models_stack, weights, all_chi_b_alphas, shuffle=True, train_size=0.8)
-
-
-        #concatenate data and weights and hyperparams
-        training_data = np.concatenate((train_models_stack, train_weights, training_hps_stack), axis=1)
-        val_data = np.concatenate((validation_models_stack, validation_weights, validation_hps_stack), axis=1)"""
-
-        #save mapping constants in flow model directory
-        mappings = np.asarray([max_logit_mchirp, max_mchirp, max_logit_q, max_q, max_logit_z, max_z])
-        np.save(f'{filepath}{self.channel_label}_mappings.npy',mappings)
         
-        return(training_data, val_data, mappings)
+        #concatenate training and validation data in order: samples, hyperparameters, weights
+        training_data = np.concatenate((train_models_stack, training_hps_stack, train_weights), axis=1)
+        val_data = np.concatenate((validation_models_stack, validation_hps_stack, validation_weights), axis=1)
+        
+        return(training_data, val_data)
 
     def sample(self, conditional, N=1):
         """
@@ -374,7 +296,7 @@ class FlowModel(Model):
         #map samples back from logit space
         samps = np.zeros(np.shape(logit_samps))
         for pidx, param in enumerate(self.param_dict):
-            samps[:,pidx] = self.expistic(logit_samps[:,pidx], self.param_dict[param]['mappings'][0], self.param_dict[param]['mappings'][1])
+            samps[:,pidx] = self.expistic(logit_samps[:,pidx], self.param_dict[param]['logit_max'], self.param_dict[param]['max'])
 
         return samps
 
@@ -492,7 +414,7 @@ class FlowModel(Model):
 
         #compute logistic mappings of data
         for pidx, param in enumerate(self.param_dict):
-            mapped_data[:,:,pidx] = self.logistic(data[:,:,pidx], False, self.param_dict[param]['mappings'][0], self.param_dict[param]['mappings'][1])
+            mapped_data[:,:,pidx] = self.logistic(data[:,:,pidx], False, self.param_dict[param]['logit_max'], self.param_dict[param]['max'])
 
         return mapped_data
 
@@ -575,7 +497,7 @@ class FlowModel(Model):
             data *=rescale_max
         return(data)
 
-    def train(self, no_trans, no_neurons, no_blocks, no_bins, lr, epochs, batch_no, filepath):
+    def train(self, no_trans, no_neurons, no_blocks, no_bins, lr, epochs, batch_no, filepath, device):
         """
         Trains the normalising flow with certain configuration of flow network parameters.
         Saves these network parameters to a json config file, and saves flow post training
@@ -596,31 +518,16 @@ class FlowModel(Model):
             the number of samples to use for a batch of training
         filepath : str
             the directory to save the flow models and associated config
-        use_wandb : bool
-            whether or not to use Weights and Biases network optimisation to train the flow and track its loss etc
+        deivce : str
+            Device on which to run the flow. Either is 'cpu', otherwise choose 'cuda:X' where X is the GPU slot.
         """
 
-        #write or append channel config to json file
-        channel_config = {'transforms':no_trans, 'neurons':no_neurons,'blocks':no_blocks,'bins':no_bins}
+        #define flow hyperparams as class properties
+        self.no_trans = no_trans
+        self.no_neurons = no_neurons
+        self.no_blocks = no_neurons
+        self.no_bins = no_bins
 
-        self.no_trans = channel_config['transforms']
-        self.no_neurons = channel_config['neurons']
-        self.no_blocks = channel_config['blocks']
-        self.no_bins = channel_config['bins']
-
-        channel_json = {}
-        channel_json[self.channel_label] = channel_config
-
-        #check if config exists e.g. for other channels, and update this channel to current config
-        if os.path.isfile(f'{filepath}flowconfig.json'):
-            with open(f'{filepath}flowconfig.json', 'r') as f:
-                old_config = json.load(f)
-            old_config[self.channel_label] = channel_config
-            channel_json = old_config
-
-        #write this channels config to file
-        with open(f'{filepath}flowconfig.json', 'w') as f:
-            json.dump(channel_json, f)
 
         #TO CHANGE - make this a settable parameter
         batch_size=10000
@@ -630,11 +537,35 @@ class FlowModel(Model):
                     self.total_smdls, RNVP=False, device=device)
 
         #map the training samples etc 
-        training_data, val_data, self.mappings = self.map_samples(filepath)
+        training_data, val_data = self.map_samples(filepath)
+
+        #write or append channel config to json file
+        channel_config = {'transforms':no_trans, 'neurons':no_neurons,'blocks':no_neurons,'bins':no_bins}
+
+        #set mapping parameters into channel config
+        for param in self.param_dict:
+            if self.param_dict[param]['transf'] == 'logit':
+                channel_config[param] = {'logit_max':self.param_dict[param]['logit_max'], 'max':self.param_dict[param]['max']}
+
+        channel_json = {}
+        channel_json[self.channel_label] = channel_config
+
+        #check if config exists e.g. for other channels, and update this channel to current config
+        if os.path.isfile(f'{filepath}flowconfig.json'):
+            with open(f'{filepath}flowconfig.json', 'r') as f:
+                old_config = json.load(f)
+            #update the old config of this channel
+            old_config[self.channel_label] = channel_config
+            #load old config of other channels
+            channel_json = old_config
+
+        #write this channels config to file
+        with open(f'{filepath}flowconfig.json', 'w') as f:
+            json.dump(channel_json, f)
 
         save_filename = f'{filepath}{self.channel_label}'
         #train the normalising flow
-        self.flow.trainval(lr, epochs, batch_no, save_filename, training_data, val_data, use_wandb)
+        self.flow.trainval(lr, epochs, batch_no, save_filename, training_data, val_data)
 
     def load_model(self, filepath, device='cpu'):
         """
@@ -644,25 +575,32 @@ class FlowModel(Model):
         -------
         filepath : str
             directory with saved flow model and config
+        deivce : str
+            Device on which to run the flow. Either is 'cpu', otherwise choose 'cuda:X' where X is the GPU slot.
         """
         #load no. transforms, no. neurons and no. bins from config and reinitialise flow if config for flows exists
         if os.path.isfile(f'{filepath}flowconfig.json'):
             with open(f'{filepath}flowconfig.json', 'r') as f:
                 config = json.load(f)
+            #load flow hyperparameters
             self.no_trans = config[self.channel_label]['transforms']
             self.no_neurons = config[self.channel_label]['neurons']
             self.no_blocks = config[self.channel_label]['blocks']
             self.no_bins = config[self.channel_label]['bins']
-            batch_size=10000
+            #load parameter mapings
+            for param in self.param_dict:
+                if self.param_dict[param]['transf'] == 'logit':
+                    for key in ['logit_max', 'max']:
+                        self.param_dict[param][key] = config[self.channel_label][key]
         else:
-            print("no config available")
+            raise Exception("no config available")
 
+        batch_size=10000
         self.flow = NFlow(self.no_trans, self.no_neurons, self.no_blocks, self.no_bins, self.no_params, self.conditionals, batch_size,\
             self.total_smdls, self.channel_label, RNVP=False, device=device)
         
         #load in actual flow model, and mappings
         self.flow.load_model(f'{filepath}{self.channel_label}.pt')
-        self.mappings = np.load(f'{filepath}{self.channel_label}_mappings.npy', allow_pickle=True)
 
     def get_alpha(self, hyperparams):
         """
@@ -679,22 +617,13 @@ class FlowModel(Model):
             value of detection efficiency for specified [chi_b, {alpha_CE}]
         """
 
-        #reshape detection efficiency values onto 2D array or shape len(chi_b), len(alpha_CE) if CE channel
-        #len(alpha_CE)=1 for non-CE channels
-        alpha_grid = np.reshape(tuple(self.alpha.values()), (len(self.hps[0]),len(self.hps[1])))
+        #reshape detection efficiency values onto grid the shape of hyperparameter values
+        hp_grid_shape = [len(self.hyperparam_models[i]) for i in range(len(self.hyperparam_models))]
+        alpha_grid = np.reshape(tuple(self.alpha.values()), (hp_grid_shape))
 
-        #CE case with 2D interpolation
-        if self.channel_label == "CE":
-            #initialise interpolator over chi_b, log(alpha_CE) to interolate log(detection efficiency)
-            alpha_interp = sp.interpolate.RegularGridInterpolator((self.hps[0],np.log(self.hps[1])), np.log(alpha_grid),\
-                bounds_error=False, method='pchip', fill_value=None)
-            #find alpha at specified chi_b, log(alpha_CE)
-            alpha = np.exp(alpha_interp([hyperparams[0][0], hyperparams[0][1]]))
-
-        else:
-            #interpolate log alpha over chi_b values
-            alpha_interp = sp.interpolate.RegularGridInterpolator([self.hps[0]], np.log(np.reshape(alpha_grid, len(self.hps[0]))),\
+        #initialise interpolator over hyperparameters to interolate log(detection efficiency)
+        alpha_interp = sp.interpolate.RegularGridInterpolator((self.hp_vals), np.log(alpha_grid),\
             bounds_error=False, method='pchip', fill_value=None)
-            #return alpha at specified chi_b
-            alpha = np.exp(alpha_interp([hyperparams[0]]))
+        #find alpha at specified chi_b, log(alpha_CE)
+        alpha = np.exp(alpha_interp(hyperparams))
         return alpha

--- a/populations/Pop_Flows.py
+++ b/populations/Pop_Flows.py
@@ -51,7 +51,7 @@ class Model(object):
 
 class FlowModel(Model):
     @staticmethod
-    def from_samples(channel, samples, params, flow_path, sensitivity=None, device='cpu'):
+    def from_samples(channel, samples, params, channel_hyperparams, smdl_indxs_combos, flow_path, sensitivity=None, device='cpu'):
         """
         Generate a Flow model instance from `samples`, where `params` are series in the `samples` dataframe. 
         
@@ -82,10 +82,55 @@ class FlowModel(Model):
         ----------
         FlowModel : obj
         """
-        return FlowModel(channel, samples, params, flow_path, sensitivity, device=device)
+
+        #set model keys for specified training data
+        self.model_keys = smdl_indxs_combos
+
+        #initialise dictionaries of alpha, cosmo_weights, pdet, optimal_snrs, and combined_weights for each submodel
+        alpha = dict.fromkeys(samples.keys())
+        cosmo_weights= dict.fromkeys(samples.keys())
+        combined_weights= dict.fromkeys(samples.keys())
+
+        for model_idxs in self.model_keys:
+            #grab samples for each submodel according to key in samples dict
+            if model_idxs.ndim > 0:
+                dict_key = tuple(model_idxs)
+            else:
+                dict_key = model_idxs
+            sbml_samps = samples[dict_key]
+
+            #check that defined sensitivity exists in submodel dataframe
+            if sensitivity is not None:
+                if 'pdet_'+sensitivity not in sbml_samps.columns:
+                    raise ValueError("{0:s} was specified for your detection weights, but cannot find this column in the samples datafarme!")
+
+            # get *\alpha* for each model, defined as \int p(\theta|\lambda) Pdet(\theta) d\theta
+            if sensitivity is not None:
+                # if cosmological weights are provided, do mock draws from the pop
+                if 'weight' in sbml_samps.keys():
+                    mock_samp = sbml_samps.sample(int(1e6), weights=(sbml_samps['weight']/len(sbml_samps)), replace=True)
+                else:
+                    mock_samp = sbml_samps.sample(int(1e6), replace=True)
+                alpha[dict_key]=np.sum(mock_samp['pdet_'+sensitivity]) / len(mock_samp)
+            else:
+                alpha[dict_key]=1.0
+
+            ### GET WEIGHTS ###
+            # if cosmological weights are provided...
+            if 'weight' in sbml_samps.keys():
+                cosmo_weights[dict_key] = np.asarray(sbml_samps['weight']) 
+            else:
+                cosmo_weights[dict_key] = np.ones(len(sbml_samps))
+
+            # Normalise the cosmological weights. If wanted detection weighted samples, cosmo weigths could be combined with pdets
+            if (cosmo_weights[dict_key] is not None):
+                combined_weights[dict_key] = (cosmo_weights[dict_key] / np.sum(cosmo_weights[dict_key]))
+            else:
+                combined_weights[dict_key] = np.ones(len(sbml_samps))
+        return FlowModel(channel, samples, params, flow_path, channel_hyperparams, combined_weights, alpha, device=device)
 
 
-    def __init__(self, channel, samples, params, flow_path, sensitivity, device):
+    def __init__(self, channel, samples, param_dict, flow_path, channel_hyperparams, combined_weights, alpha, device):
         """
         Initialisation for FlowModel object. Sets self.flow as instance of Nflow class, of which FlowModel is wrapper of that object.
 
@@ -111,123 +156,39 @@ class FlowModel(Model):
         super()
         self.channel_label = channel
         self.samples = samples
-        self.params = params
-        self.sensitivity = sensitivity
 
-        #initialises list of population hyperparameter values
-        self.hps = [[0.,0.1,0.2,0.5]]
-        self.param_bounds = [_param_bounds[param] for param in self.params]
+        #want this to be structured {'mchirp':{'bounds':(0,100.), 'max':(100.)}, 'q':{...}, 'chieff:{...}}
+        self.param_dict = param_dict
+        #i think we don't need the below: instead we can loop thru param_dict
+        #self.params = self.param_dict["keys"]
+        #self.param_bounds = self.param_dict["bounds"]
 
-        #additional alpha dimension for CE channel, else dummy dimension
-        if self.channel_label=='CE':
-            self.hps.append([0.2,0.5,1.,2.,5.])
-        else:
-            self.hps.append([1])
+        #initialises list of population hyperparameters from model keys
+        self.hyperparam_models = channel_hyperparams["keys"]
+        self.hp_vals = channel_hyperparams["values"]
+
+        #retrieve hyperparameter values from model keys
+        #TO CHANGE - NEEDS GENERALISING, currently assumes values are last 2 digits of model keys /10
+        #self.hp_vals = []
+        """for d, dim in enumerate(self.hyperparam_models):
+            self.hp_vals.append([])
+            for smdl in dim:
+                self.hp_vals[d].append(float(smdl[-2:])/10)"""
         
         #number of binary parameters
         self.no_params = np.shape(params)[0]
         #dimensionailty of non-branching ratio hyperparameters
-        self.conditionals = 2 if self.channel_label =='CE' else 1
+        self.conditionals = len(self.hyperparam_models)
 
-        #initialise dictionaries of alpha, cosmo_weights, pdet, optimal_snrs, and combined_weights for each submodel
-        alpha = dict.fromkeys(samples.keys())
-        cosmo_weights= dict.fromkeys(samples.keys())
-        pdets= dict.fromkeys(samples.keys())
-        optimal_snrs= dict.fromkeys(samples.keys())
-        combined_weights= dict.fromkeys(samples.keys())
-
-        #loop over submodels
-        for chib_id, chib in enumerate(self.hps[0]):
-            for alphaid, alphaCE in enumerate(self.hps[1]):
-
-                #grab samples for each submodel depending on how many hyperparameter dimensions there are (CE vs non-CE)
-                if self.channel_label=='CE':
-                    sbml_samps = samples[chib_id,alphaid]
-                    key = chib_id,alphaid
-                else:
-                    sbml_samps = samples[chib_id]
-                    key= chib_id
-
-                #check that defined sensitivity exists in submodel dataframe
-                if sensitivity is not None:
-                    if 'pdet_'+sensitivity not in sbml_samps.columns:
-                        raise ValueError("{0:s} was specified for your detection weights, but cannot find this column in the samples datafarme!")
-
-                # get *\alpha* for each model, defined as \int p(\theta|\lambda) Pdet(\theta) d\theta
-                if sensitivity is not None:
-                    # if cosmological weights are provided, do mock draws from the pop
-                    if 'weight' in sbml_samps.keys():
-                        mock_samp = sbml_samps.sample(int(1e6), weights=(sbml_samps['weight']/len(sbml_samps)), replace=True)
-                    else:
-                        mock_samp = sbml_samps.sample(int(1e6), replace=True)
-                    alpha[key]=np.sum(mock_samp['pdet_'+sensitivity]) / len(mock_samp)
-                else:
-                    alpha[key]=1.0
-
-                ### GET WEIGHTS ###
-                # if cosmological weights are provided...
-                if 'weight' in sbml_samps.keys():
-                    cosmo_weights[key] = np.asarray(sbml_samps['weight'])
-                else:
-                    cosmo_weights[key] = np.ones(len(sbml_samps))
-                # if detection weights are provided...
-                if sensitivity is not None:
-                    pdets[key] = np.asarray(sbml_samps['pdet_'+sensitivity])
-                else:
-                    pdets[key] = np.ones(len(sbml_samps))
-
-                # get optimal SNRs for this sensitivity
-                if sensitivity is not None:
-                    optimal_snrs[key] = np.asarray(sbml_samps['snropt_'+sensitivity])
-                else:
-                    optimal_snrs[key] = np.nan*np.ones(len(sbml_samps))
-
-
-                # Normalise the cosmological weights. If wanted detection weighted samples, cosmo weigths could be combined with pdets
-                if (cosmo_weights[key] is not None):
-                    combined_weights[key] = (cosmo_weights[key] / np.sum(cosmo_weights[key]))
-                else:
-                    combined_weights[key] = np.ones(len(sbml_samps))
-
-        #sets weights as class properties
+        #set weights as class properties
         self.combined_weights = combined_weights
-        self.pdets = pdets
-        self.optimal_snrs = optimal_snrs
         self.alpha = alpha
-        self.cosmo_weights = cosmo_weights
-        
-        #Load flow network parameters from config file if it exists
-        if os.path.isfile(f'{flow_path}flowconfig.json'):
-            with open(f'{flow_path}flowconfig.json', 'r') as f:
-                config = json.load(f)
-        else:
-            config = {}
-
-        if self.channel_label in list(config.keys()):
-            self.no_trans = config[self.channel_label]['transforms']
-            self.no_neurons = config[self.channel_label]['neurons']
-            self.no_bins = config[self.channel_label]['bins']
-        else:
-            self.no_trans = 6
-            self.no_neurons = 128
-            self.no_bins=4
-            if self.channel_label=='CE' or self.channel_label=='NSC':
-                self.no_bins=5
-
-        batch_size=10000
 
         #initialise the channel of this flow and how many training submodels exist for this channel
-        self.total_hps = np.shape(self.hps[0])[0]*np.shape(self.hps[1])[0]
-        channel_ids = {'CE':0, 'CHE':1,'GC':2,'NSC':3, 'SMT':4}
-        self.channel_id = channel_ids[self.channel_label] #will be 0, 1, 2, 3, or 4
-
-        #initislises flow network
-        flow = NFlow(self.no_trans, self.no_neurons, self.no_params, self.conditionals, batch_size, 
-                    self.total_hps, self.channel_label, RNVP=False, device=device, no_bins=self.no_bins)
-        self.flow = flow
+        self.total_smdls = len(model_keys)
 
 
-    def map_samples(self, samples, params, filepath, testCEsmdl=False):
+    def map_samples(self, filepath):
         """
         Maps samples with logistic mapping (mchirp, q, z samples) and tanh (chieff).
         Stacks data by [mchirp,q,chieff,z,weight,chi_b,(alpha)].
@@ -262,83 +223,66 @@ class FlowModel(Model):
 
         print('Mapping population synthesis samples for training...')
         
-
-        if self.channel_label != 'CE':
-            #Channels with 1D hyperparameters: SMT, GC, NSC, CHE
-
-
-            #measure no_samples in models and identify samples with weights below fmin
-            model_size = np.zeros(self.no_params)
-            cumulsize = np.zeros(self.no_params)
-            weights_idxs = []
-            
-            for chib_id, xb in enumerate(self.hps[0]):
-                weights_temp=np.asarray(self.combined_weights[(chib_id)])
-                weights_idxs.append(np.argwhere((weights_temp) > np.finfo(np.float32).tiny))
-                model_size[chib_id] = np.shape(weights_idxs[chib_id])[0]
-                cumulsize[chib_id] = np.sum(model_size)
-
-            self.no_binaries = int(cumulsize[-1])
-            models = np.zeros((self.no_binaries, self.no_params))
-            weights = np.zeros((self.no_binaries, 1))
-            cumulsize = np.append(cumulsize, 0)
-
-            #moves binary parameter samples and weights from dictionaries into array
-            for chib_id, xb in enumerate(self.hps[0]):
-                models[int(cumulsize[chib_id-1]):int(cumulsize[chib_id])]=np.reshape(np.asarray(samples[(chib_id)][params])[weights_idxs[chib_id]],(-1,len(params)))
-                weights[int(cumulsize[chib_id-1]):int(cumulsize[chib_id])]=np.asarray(self.combined_weights[(chib_id)])[weights_idxs[chib_id]]
-
-            models_stack = np.copy(models)
-
-            #map samples with logistic mapping before dividing into training and validation data
-
-            #mchirp
-            models_stack[:,0], max_logit_mchirp, max_mchirp = self.logistic(models_stack[:,0],wholedataset=True, \
-                rescale_max=self.param_bounds[0][1])
-
-            #q
-            if self.channel_id == 2:
-                #add extra tiny amount to GC mass ratios as q=1 samples exist
-                models_stack[:,1], max_logit_q, max_q = self.logistic(models_stack[:,1],wholedataset=True, \
-                rescale_max=self.param_bounds[1][1]+0.001)
+        #measure no_samples in models and identify samples with weights below fmin
+        model_size = np.zeros(self.total_smdls)
+        cumulsize = np.zeros(self.total_smdls)
+        weights_idxs = []
+        
+        for i, model_idxs in enumerate(self.model_keys):
+            #find corresponding submodel key
+            if model_idxs.ndim > 0:
+                dict_key = tuple(model_idxs)
             else:
-                models_stack[:,1], max_logit_q, max_q = self.logistic(models_stack[:,1],wholedataset=True, \
-                rescale_max=self.param_bounds[1][1])
+                dict_key = model_idxs
 
-            #chieff
-            models_stack[:,2] = np.arctanh(models_stack[:,2])
+            weights_temp=np.asarray(self.combined_weights[dict_key])
+            weights_idxs.append(np.argwhere((weights_temp) > np.finfo(np.float32).tiny))
+            model_size[i] = np.shape(weights_idxs[i])[0]
+            cumulsize[i] = np.sum(model_size)
 
-            #z
-            models_stack[:,3],max_logit_z, max_z = self.logistic(models_stack[:,3],wholedataset=True, \
-                rescale_max=self.param_bounds[3][1])
+        self.no_binaries = int(cumulsize[-1])
+        models = np.zeros((self.no_binaries, self.no_params))
+        weights = np.zeros((self.no_binaries, 1))
+        cumulsize = np.append(cumulsize, 0)
+
+        #moves binary parameter samples and weights from dictionaries into array
+        for i, model_idxs in enumerate(self.model_keys):
+            models[int(cumulsize[i-1]):int(cumulsize[i])]=np.reshape(np.asarray(self.samples[model_idxs][params])[weights_idxs[i]],(-1,len(params)))
+            weights[int(cumulsize[i-1]):int(cumulsize[i])]=np.asarray(self.combined_weights[model_idxs])[weights_idxs[i]]
+
+        models_stack = np.copy(models)
+
+        #map samples with logistic mapping before dividing into training and validation data
+
+        mappings = dict(fromkeys(params,{'logit_max', 'max'})
+
+        for pidx, param in enumerate(self.param_dict):
+            models_stack[:,pidx], mappings['logit_max'], mappings['max'] = self.logistic(models_stack[:,pidx],wholedataset=True, \
+                rescale_max=self.param_dict[param]['bounds'][1])
             
-            #repeat subpopulation hyperparameter values no samples times for each subpopulation
-            #then split the training data, conditional data, and sample weights into training and validation sets
-            training_hps_stack = np.repeat(self.hps[0], (model_size).astype(int), axis=0)
-            training_hps_stack = np.reshape(training_hps_stack,(-1,self.conditionals))
-            weights = np.reshape(weights,(-1,1))
-            train_models_stack, validation_models_stack, train_weights, validation_weights, training_hps_stack, validation_hps_stack = \
-                    train_test_split(models_stack, weights, training_hps_stack, shuffle=True, train_size=0.8)
+        #repeat subpopulation hyperparameter values Nsamps times for each subpopulation
+        hp_combos = np.squeeze(list(product(*self.hps)))
+        hps_stack = np.repeat(training_hps, (model_size).astype(int), axis=0)
+
+        #reshape conditionals and weights
+        hps_stack = np.reshape(hps_stack,(-1,self.conditionals))
+        weights = np.reshape(weights,(-1,1))
+
+        #split the training data, conditional data, and sample weights into training and validation sets
+        train_models_stack, validation_models_stack, train_weights, validation_weights, training_hps_stack, validation_hps_stack = \
+                train_test_split(models_stack, weights, hps_stack, shuffle=True, train_size=0.8)
             
-        else:
+        """else:
             #CE channel with alpha_CE parameter
 
-            #sets test population to remove, test_model_id is the model indices of the removed population
-            if testCEsmdl:
-                test_model_id = [1,2]
-                test_model_id_flat = 7
-
             #tile list of chi_bs and alpha_CEs into liost for each training sub-population
-            chi_b_alpha_pairs= np.zeros((self.total_hps, 2))
+            chi_b_alpha_pairs= np.zeros((self.total_smdls, 2))
             chi_b_alpha_pairs[:,0] = np.repeat(self.hps[0],np.shape(self.hps[1])[0])
             chi_b_alpha_pairs[:,1] = np.tile(np.log(self.hps[1]), np.shape(self.hps[0])[0])
-            if testCEsmdl:
-                chi_b_alpha_pairs = np.delete(chi_b_alpha_pairs, test_model_id_flat, axis=0)
-                self.total_hps = self.total_hps - 1
 
             #initialise arrays for model size
             model_size = np.zeros((4,5))
-            cumulsize = np.zeros(self.total_hps)
+            cumulsize = np.zeros(self.total_smdls)
             weights_idxs = []
 
             #meaure no samples in each population, and the cumulative samples in each population used for training
@@ -371,11 +315,6 @@ class FlowModel(Model):
                     weights[int(cumulsize[i-1]):int(cumulsize[i])]=np.reshape(np.asarray(self.combined_weights[(chib_id, alpha_id)])[weights_idxs[i]],(-1,1))
                     i+=1
 
-            #reshape the model size array to be 1D
-            flat_model_size = np.reshape(model_size, 20)
-            if testCEsmdl:
-                flat_model_size = np.delete(flat_model_size, test_model_id_flat)
-
             #repeat the pairs of [chi_b, alphaCE] for the number of samples in the training samples
             all_chi_b_alphas = np.repeat(chi_b_alpha_pairs, (flat_model_size).astype(int), axis=0)
 
@@ -405,7 +344,7 @@ class FlowModel(Model):
 
         #concatenate data and weights and hyperparams
         training_data = np.concatenate((train_models_stack, train_weights, training_hps_stack), axis=1)
-        val_data = np.concatenate((validation_models_stack, validation_weights, validation_hps_stack), axis=1)
+        val_data = np.concatenate((validation_models_stack, validation_weights, validation_hps_stack), axis=1)"""
 
         #save mapping constants in flow model directory
         mappings = np.asarray([max_logit_mchirp, max_mchirp, max_logit_q, max_q, max_logit_z, max_z])
@@ -428,19 +367,15 @@ class FlowModel(Model):
         samps : array
             samples in shape [N, no_params]
         """
-        #log alphaCE
-        if self.channel_label =='CE':
-            conditional[1] = np.log(conditional[1])
         
         #sample from flow - this returns samples in the logistically mapped space
         logit_samps = self.flow.sample(conditional,N)
 
         #map samples back from logit space
         samps = np.zeros(np.shape(logit_samps))
-        samps[:,0] = self.expistic(logit_samps[:,0], self.mappings[0], self.mappings[1])
-        samps[:,1] = self.expistic(logit_samps[:,1], self.mappings[2], self.mappings[3])
-        samps[:,2] = np.tanh(logit_samps[:,2])
-        samps[:,3] = self.expistic(logit_samps[:,3], self.mappings[4], self.mappings[5])
+        for pidx, param in enumerate(self.param_dict):
+            samps[:,pidx] = self.expistic(logit_samps[:,pidx], self.param_dict[param]['mappings'][0], self.param_dict[param]['mappings'][1])
+
         return samps
 
     def __call__(self, data, conditional_hps, smallest_N, prior_pdf=None):
@@ -524,12 +459,8 @@ class FlowModel(Model):
         samps mapped to latent space
         """
 
-        #logs alphaCE
         conditional = np.asarray(conditional)
-        if self.channel_label =='CE':
-            conditional[1] = np.log(conditional[1])
         
-
         #maps observations into the logistically mapped space
         mapped_obs = self.map_obs(samps)
 
@@ -560,10 +491,8 @@ class FlowModel(Model):
         mapped_data = np.zeros((np.shape(data)[0],np.shape(data)[1],np.shape(data)[2]))
 
         #compute logistic mappings of data
-        mapped_data[:,:,0],_,_= self.logistic(data[:,:,0], False, max=self.mappings[0], rescale_max=self.mappings[1])
-        mapped_data[:,:,1],_,_= self.logistic(data[:,:,1], False, max=self.mappings[2], rescale_max=self.mappings[3])
-        mapped_data[:,:,2]= np.arctanh(data[:,:,2])
-        mapped_data[:,:,3],_,_= self.logistic(data[:,:,3], False, max=self.mappings[4], rescale_max=self.mappings[5])
+        for pidx, param in enumerate(self.param_dict):
+            mapped_data[:,:,pidx] = self.logistic(data[:,:,pidx], False, self.param_dict[param]['mappings'][0], self.param_dict[param]['mappings'][1])
 
         return mapped_data
 
@@ -646,7 +575,7 @@ class FlowModel(Model):
             data *=rescale_max
         return(data)
 
-    def train(self, no_trans, no_bins, no_neurons, lr, epochs, batch_no, filepath, testCEsmdl, use_wandb=False):
+    def train(self, no_trans, no_neurons, no_blocks, no_bins, lr, epochs, batch_no, filepath):
         """
         Trains the normalising flow with certain configuration of flow network parameters.
         Saves these network parameters to a json config file, and saves flow post training
@@ -672,11 +601,17 @@ class FlowModel(Model):
         """
 
         #write or append channel config to json file
-        channel_config = {'transforms':no_trans, 'neurons':no_neurons,'bins':no_bins}
+        channel_config = {'transforms':no_trans, 'neurons':no_neurons,'blocks':no_blocks,'bins':no_bins}
+
+        self.no_trans = channel_config['transforms']
+        self.no_neurons = channel_config['neurons']
+        self.no_blocks = channel_config['blocks']
+        self.no_bins = channel_config['bins']
+
         channel_json = {}
         channel_json[self.channel_label] = channel_config
 
-        #check if config exists e.g. for other channels
+        #check if config exists e.g. for other channels, and update this channel to current config
         if os.path.isfile(f'{filepath}flowconfig.json'):
             with open(f'{filepath}flowconfig.json', 'r') as f:
                 old_config = json.load(f)
@@ -687,8 +622,15 @@ class FlowModel(Model):
         with open(f'{filepath}flowconfig.json', 'w') as f:
             json.dump(channel_json, f)
 
+        #TO CHANGE - make this a settable parameter
+        batch_size=10000
+
+        #initislises flow network
+        self.flow = NFlow(self.no_trans, self.no_neurons, self.no_blocks, self.no_bins, self.no_params, self.conditionals, batch_size, 
+                    self.total_smdls, RNVP=False, device=device)
+
         #map the training samples etc 
-        training_data, val_data, self.mappings = self.map_samples(self.samples, self.params, filepath, testCEsmdl)
+        training_data, val_data, self.mappings = self.map_samples(filepath)
 
         save_filename = f'{filepath}{self.channel_label}'
         #train the normalising flow
@@ -707,12 +649,16 @@ class FlowModel(Model):
         if os.path.isfile(f'{filepath}flowconfig.json'):
             with open(f'{filepath}flowconfig.json', 'r') as f:
                 config = json.load(f)
+            self.no_trans = config[self.channel_label]['transforms']
             self.no_neurons = config[self.channel_label]['neurons']
+            self.no_blocks = config[self.channel_label]['blocks']
             self.no_bins = config[self.channel_label]['bins']
             batch_size=10000
+        else:
+            print("no config available")
 
-            self.flow = NFlow(self.no_trans, self.no_neurons, self.no_params, self.conditionals, batch_size,\
-                self.total_hps, self.channel_label, RNVP=False, device=device, no_bins=self.no_bins)
+        self.flow = NFlow(self.no_trans, self.no_neurons, self.no_blocks, self.no_bins, self.no_params, self.conditionals, batch_size,\
+            self.total_smdls, self.channel_label, RNVP=False, device=device)
         
         #load in actual flow model, and mappings
         self.flow.load_model(f'{filepath}{self.channel_label}.pt')
@@ -752,69 +698,3 @@ class FlowModel(Model):
             #return alpha at specified chi_b
             alpha = np.exp(alpha_interp([hyperparams[0]]))
         return alpha
-
-
-    def wandb_init(self, epochs):
-        """
-        Initialises a wandb sweep and then uses a wandb agent to train a flow under that sweeps regimes
-        current process optimises the number of epochs over validation loss, 
-        the prior for the number of epochs being uniform between argument's number of epochs and 3*args.epochs
-        """
-        #setting up wandb sweep parameters
-
-        sweep_config = {
-            'method': 'bayes'
-            }
-
-        metric = {
-            'name': 'val_loss',
-            'goal': 'minimize'   
-            }
-
-        sweep_config['metric'] = metric
-
-        parameters_dict = {
-            'lr': {
-                'value':0.001
-            },
-            'epochs': {
-                'value':10000
-            },
-            'batch_no': {
-                'value':10
-            },
-            'no_trans': {
-                'distribution': 'int_uniform',
-                'min': 4,
-                'max': 10
-            },
-            'no_neurons': {
-                'distribution': 'int_uniform',
-                'min': 12,
-                'max': 128
-            },
-            'no_bins': {
-                'distribution': 'int_uniform',
-                'min': 3,
-                'max': 8
-            }                
-            }
-
-        sweep_config['parameters'] = parameters_dict
-
-        sweep_id = wandb.sweep(sweep_config, project=f"{self.channel_label}_transneubins_sweep")
-        
-        wandb.agent(sweep_id, self.wandbtrain, count=20)
-    
-    def wandbtrain(self, config=None):
-        with wandb.init(config=config):
-            config = wandb.config
-
-            batch_size=10000
-            total_hps = np.shape(self.hps[0])[0]*np.shape(self.hps[1])[0]
-            device='cuda:0'
-
-            flow = NFlow(config.no_trans, config.no_neurons, self.no_params, self.conditionals, self.no_binaries, batch_size, 
-                    total_hps, self.channel_label, RNVP=False, device=device, no_bins=config.no_bins)
-            self.flow = flow
-            self.train(config.lr, config.epochs, config.batch_no, f"./wandb_models/{wandb.run.id}_wandb", self.channel_label, True)

--- a/populations/bbh_models.py
+++ b/populations/bbh_models.py
@@ -73,7 +73,7 @@ def read_hdf5(path, channel, channel_smdl_names, smdl_indxs_combos):
     return(popsynth_outputs)
 
 
-def get_models(file_path, channels, params, use_flows, sensitivity=None, normalize=False, detectable=False, device='cpu', flow_path=None, **kwargs):
+def get_models(file_path, channels, param_dict, use_flows, full_hyperparam_dict, sensitivity=None, normalize=False, detectable=False, device='cpu', flow_path=None, **kwargs):
     """
     Call this to get all the models and submodels, as well
     as KDEs of these models, packed inside of dictionaries labelled in the
@@ -158,10 +158,17 @@ def get_models(file_path, channels, params, use_flows, sensitivity=None, normali
             channel_smdls_split = np.array([x.split('/')[1:] for x in deepest_models if chnl+'/' in x])
             smdl_indices = [list(np.arange(hyperparam_pts_per_dim[i])) for i in range(channel_smdls_split.shape[1])]
             smdl_indxs_combos = np.squeeze(list(product(*smdl_indices)))
-            channel_hyperparams = [hyperparam_dict[i] for i in range(channel_smdls_split.shape[1])]
+
+            #currently list of lists of hyperparam model strings
+            #channel_hyperparams = [hyperparam_dict[i] for i in range(channel_smdls_split.shape[1])]
+            #instead want this, assuming hyperparam_dict contains values and keys:
+            channel_hyperparams = {}
+            for hp in full_hyperparam_dict:
+                if chnl in full_hyperparam_dict[hp]['channels']:
+                    channel_hyperparams[hp] = full_hyperparam_dict[hp]
 
             popsynth_outputs = read_hdf5(file_path, chnl, channel_smdls, smdl_indxs_combos)
-            flow_models[chnl] = FlowModel.from_samples(chnl, popsynth_outputs, params, channel_hyperparams, smdl_indxs_combos, device=device, sensitivity=sensitivity, flow_path=flow_path)
+            flow_models[chnl] = FlowModel.from_samples(chnl, popsynth_outputs, param_dict, channel_hyperparams, smdl_indxs_combos, sensitivity=sensitivity, flow_path=flow_path)
         return deepest_models, flow_models
     else:
         kde_models = {}
@@ -175,7 +182,7 @@ def get_models(file_path, channels, params, use_flows, sensitivity=None, normali
                         # if we are on the last level, read in data and store kdes
                         df = pd.read_hdf(file_path, key=smdl)
                         label = '/'.join(smdl_list)
-                        mdl = KDEModel.from_samples(label, df, params, sensitivity=sensitivity, normalize=normalize, detectable=detectable, **kwargs)
+                        mdl = KDEModel.from_samples(label, df, list(param_dict.keys()), sensitivity=sensitivity, normalize=normalize, detectable=detectable, **kwargs)
                         current_level[part] = mdl
                     else:
                         current_level[part] = {}

--- a/populations/bbh_models.py
+++ b/populations/bbh_models.py
@@ -3,6 +3,7 @@ import numpy as np
 import pandas as pd
 import h5py
 from tqdm import tqdm
+from itertools import product
 
 from . import *
 from .utils.transform import _DEFAULT_TRANSFORMS, _to_chieff, \
@@ -44,46 +45,8 @@ def get_params(df, params):
                 raise NameError("You specified the parameter {0:s} for inference, but it is not in your population data and you haven't written a transformation to calculate it!".format(param))
 
     return df
-    
-def get_model_keys(path, channel):
-    all_models = []
-    models = []
-    def find_submodels(name, obj):
-        if isinstance(obj, h5py.Dataset):
-            all_models.append(name.rsplit('/', 1)[0])
-            
-    f = h5py.File(path, 'r')
-    f.visititems(find_submodels)
-    # get all unique models
-    all_models = sorted(list(set(all_models)))
-    f.close()
 
-    # use only models with given alpha value
-    for model in all_models:
-        if channel in model:
-            models.append('/'+model)
-    return(np.array(models))
-
-def get_model_keys_CE(path):
-    all_models = []
-    models = []
-    def find_submodels(name, obj):
-        if isinstance(obj, h5py.Dataset):
-            all_models.append(name.rsplit('/', 1)[0])
-            
-    f = h5py.File(path, 'r')
-    f.visititems(find_submodels)
-    # get all unique models
-    all_models = sorted(list(set(all_models)))
-    f.close()
-
-    # use only models with given alpha value
-    for model in all_models:
-        if 'CE' in model:
-            models.append('/'+model)
-    return(np.split(np.array(models), 4))
-
-def read_hdf5(path, channel):
+def read_hdf5(path, channel, channel_smdl_names, smdl_indxs_combos):
     """
     For CE channel, returns diction of submodels for all chi_b and alpha_CE values, as keys i,j in dictionary
     For other channels, returns dictionary of submodels varying with chi_b for that channel
@@ -97,19 +60,16 @@ def read_hdf5(path, channel):
     Returns
     ----------
     popsynth_outputs: pandas dataframe
-        dataframe of samples from models hdf5 file, of param for each submodel in One channel (function input)
+        dataframe of samples from models hdf5 file, of param for each submodel.
     """
-    if channel=='CE':
-        popsynth_outputs = {}
-        models = np.asarray(get_model_keys_CE(path))
-        for i in range(models.shape[0]):
-            for j in range(models.shape[1]):
-                popsynth_outputs[i,j]=pd.read_hdf(path, key=models[i,j])
-    else:
-        popsynth_outputs = {}
-        models = np.asarray(get_model_keys(path, channel))
-        for i in range(len(models)):
-            popsynth_outputs[i]=pd.read_hdf(path, key=models[i])
+    popsynth_outputs = {}
+    #error handling for model keys for Nhyper>1, to set these to tuple type
+    for i, channel_smdl_name in enumerate(channel_smdl_names):
+        if smdl_indxs_combos[i].ndim > 0:
+            dict_key = tuple(smdl_indxs_combos[i])
+        else:
+            dict_key = smdl_indxs_combos[i]
+        popsynth_outputs[dict_key]=pd.read_hdf(path, key=channel_smdl_name)
     return(popsynth_outputs)
 
 
@@ -170,13 +130,38 @@ def get_models(file_path, channels, params, use_flows, sensitivity=None, normali
                     deepest_models_cut.append(mdl)
         deepest_models = deepest_models_cut
 
+    #find hyperparameters in models
+    hyperparam_dict  = {}
+    hyperidx=0
+    deepest_models.sort()
+    #list of model keys
+    hyperparams = sorted(list(set([x.split('/', 1)[1] for x in deepest_models])))
+    #total number of hyperparameters = maximum number of hyperparameters in any model
+    Nhyper = np.max([len(x.split('/')) for x in hyperparams])
+    
+    #construct hyperparam dict, with keys [0,..,Nhyper] and values the points in hyperparameter space with simulations
+    while hyperidx < Nhyper:
+        hyperidx_with_Nhyper = np.argwhere(np.asarray([len(x.split('/')) for x in hyperparams])>hyperidx).flatten()
+        hyperparams_at_level = sorted(set([x.split('/')[hyperidx] for x in np.asarray(hyperparams)[hyperidx_with_Nhyper]]))
+        hyperparam_dict[hyperidx] = hyperparams_at_level
+        hyperidx += 1
+    #length of the hyperparam dict for each dimension
+    hyperparam_pts_per_dim = [len(hyperparam_dict[x]) for x in range(Nhyper)]
+
     #KDE case: reads in submodel for each of the deepest model and sends to KDEModel
     #Flow case: reads in samples from all channels and sends to FlowModel
     if use_flows==True:
         flow_models = {}
         for i, chnl in enumerate(tqdm(channels)):
-            popsynth_outputs = read_hdf5(file_path, chnl)
-            flow_models[chnl] = FlowModel.from_samples(chnl, popsynth_outputs, params, device=device, sensitivity=sensitivity, flow_path=flow_path)
+            #find submodel keys, and indices they should correspond to in the input samples dict to the FlowModel
+            channel_smdls = [x for x in deepest_models if chnl+'/' in x]
+            channel_smdls_split = np.array([x.split('/')[1:] for x in deepest_models if chnl+'/' in x])
+            smdl_indices = [list(np.arange(hyperparam_pts_per_dim[i])) for i in range(channel_smdls_split.shape[1])]
+            smdl_indxs_combos = np.squeeze(list(product(*smdl_indices)))
+            channel_hyperparams = [hyperparam_dict[i] for i in range(channel_smdls_split.shape[1])]
+
+            popsynth_outputs = read_hdf5(file_path, chnl, channel_smdls, smdl_indxs_combos)
+            flow_models[chnl] = FlowModel.from_samples(chnl, popsynth_outputs, params, channel_hyperparams, smdl_indxs_combos, device=device, sensitivity=sensitivity, flow_path=flow_path)
         return deepest_models, flow_models
     else:
         kde_models = {}

--- a/populations/utils/flow.py
+++ b/populations/utils/flow.py
@@ -75,7 +75,7 @@ class NFlow():
 
         self.network.to(device)
 
-    def trainval(self, lr, epochs, batch_no, filename, training_data, val_data, use_wandb):
+    def trainval(self, lr, epochs, batch_no, filename, training_data, val_data):
         """
         Train the normalising flow for the specified number of epochs using a set of training and validation data,
         and save the model with the best validation loss
@@ -94,8 +94,6 @@ class NFlow():
             set of training data points for the normlising flow
         val_data : array
             set of validation data points for the normlising flow
-        use_wandb : bool
-            If true, uses weights and biases to optimise neural network parameters
         """
         #set optimiser for flow, optimises flow parameters:
         #affine - s and t that shift and scale the transforms
@@ -167,10 +165,6 @@ class NFlow():
                     '\r Epoch: {} || Training loss: {} || Validation loss: {}'.format(
                     n+1, train_loss, total_val_loss))
             
-            #track losses for weights and biases
-            if use_wandb:
-                wandb.log({"train_loss": train_loss, "val_loss": total_val_loss, "unweighted_train_KL": unweighted_KL_train, "unweighted_val_KL": total_unweighted_KL_val})
-
             #copy the best flow model
             if total_val_loss < best_val_loss:
                 best_epoch = n
@@ -279,7 +273,7 @@ class NFlow():
 
         #retrieve dataspace samples, and corresponding hyperparameters and weights to the randomly drawn samples
         batched_samples = training_samples[random_sample_idxs,:self.no_params]
-        batched_hp_pairs = training_samples[random_sample_idxs, self.no_params:self.cond_inputs]
+        batched_hp_pairs = training_samples[random_sample_idxs, self.no_params:self.no_params+self.cond_inputs]
         batch_weights = training_samples[random_sample_idxs,-1]
 
         #reshape tensors to be correct shape
@@ -307,18 +301,18 @@ class NFlow():
         """
 
         #pull batch from data
-        random_samples = np.random.choice(np.shape(validation_data)[0], size=(int(self.batch_size)))
+        random_sample_idxs = np.random.choice(np.shape(validation_data)[0], size=(int(self.batch_size)))
 
         #retrieve dataspace samples, and corresponding hyperparameters and weights to the randomly drawn samples
         batched_samples = validation_data[random_sample_idxs,:self.no_params]
-        batched_hp_pairs = validation_data[random_sample_idxs, self.no_params:self.cond_inputs]
+        batched_hp_pairs = validation_data[random_sample_idxs, self.no_params:self.no_params+self.cond_inputs]
         batch_weights = validation_data[random_sample_idxs,-1]
 
         #reshape
-        xval=torch.from_numpy(validation_samples.astype(np.float32)).to(self.device)
-        xhyperparams = torch.from_numpy(validation_hp_pairs.astype(np.float32)).to(self.device)
+        xval=torch.from_numpy(batched_samples.astype(np.float32)).to(self.device)
+        xhyperparams = torch.from_numpy(batched_hp_pairs.astype(np.float32)).to(self.device)
         xhyperparams = xhyperparams.reshape(-1,self.cond_inputs)
-        xweights = torch.from_numpy(val_weights.astype(np.float32)).to(self.device)
+        xweights = torch.from_numpy(batch_weights.astype(np.float32)).to(self.device)
         return(xval, xhyperparams, xweights)
 
     def load_model(self,filename):

--- a/populations/utils/flow.py
+++ b/populations/utils/flow.py
@@ -26,8 +26,8 @@ class NFlow():
     #initialise flow with inputs, conditionals, including the type of network, real non-volume preserving,
     #or neural spline flow
     #spline flow increases the flexibility in the flow model
-    def __init__(self, no_trans, no_neurons, training_inputs, cond_inputs,
-                batch_size, total_hps, channel_label, RNVP=True, no_bins=4, device="cpu"):
+    def __init__(self, no_trans, no_neurons, no_blocks, no_bins, training_inputs, cond_inputs,
+                batch_size, total_smdls, RNVP=False, device="cpu"):
                 
         """
         Initialise Flow with inputed data, either RNVP or Spline flow.
@@ -38,49 +38,47 @@ class NFlow():
             number of transforms to give the flow
         no_neurons : int
             number of neurons of the flow per layer/transform
+        no_blocks : int
+            number of blocks
         training_inputs : int
             number of parameters in dataspace (binary parameters)
         cond_inputs : int
-            number of conditional population hyperparameters
+            number of population hyperparameters
         batch_size : int
             number of training and validation samples to use in each batch
-        total_hps : int
+        total_smdls : int
             total number of subpopulation models
-        channel_label : str
-            str corresponding to which formation channel this flow is for, e.g. 'CE'
-        RNVP : bool
-            whether or not to use realNVP flow, if False use spline
         num_bins : int
             number of bins to use for a spline flow
+        RNVP : bool
+            whether or not to use realNVP flow, if False use spline
         device : str
             device on which to run pytorch operations, default is CPU, otherwise GPU enabled with device = 'cuda:0'
         """
         self.no_params = training_inputs
         self.batch_size = batch_size
 
-        self.total_hps = total_hps
+        self.total_smdls = total_smdls
         self.cond_inputs = cond_inputs
 
-        self.channel = channel_label
         self.device = device # cuda:X where X is the slot of the GPU. run nvidia-smi in the terminal to see gpus
 
         if RNVP:
             self.network = RealNVP(n_inputs = training_inputs, n_conditional_inputs= cond_inputs,
-                                    n_neurons = no_neurons, n_transforms = no_trans, n_blocks_per_transform = 2,
+                                    n_neurons = no_neurons, n_transforms = no_trans, n_blocks_per_transform = no_blocks,
                                     linear_transform = None, batch_norm_between_transforms=True)
         else:
             self.network = CouplingNSF(n_inputs = training_inputs, n_conditional_inputs= cond_inputs,
                                         n_neurons = no_neurons, n_transforms = no_trans,
-                                        n_blocks_per_transform = 2, batch_norm_between_transforms=True,
+                                        n_blocks_per_transform = no_blocks, batch_norm_between_transforms=True,
                                         linear_transform = None, num_bins=no_bins)
 
         self.network.to(device)
 
-    #training and validation loop for the flow
     def trainval(self, lr, epochs, batch_no, filename, training_data, val_data, use_wandb):
         """
-        Train the normalising flow for the specified number of epochs, and save the model with the best 
-        validation loss
+        Train the normalising flow for the specified number of epochs using a set of training and validation data,
+        and save the model with the best validation loss
 
         Parameters
         ----------
@@ -237,20 +235,25 @@ class NFlow():
         Parameters
         ----------
         coditional : array
-            [chi_b, alpha]
+            list/array of hyperparameter values to use as conditional values from which to sample from the flow, 
+            of shape [Nhyperparams]
         no_samples : int
             number of samples to take for each conditional
         
         Returns
         -------
         samples : array 
-            Flow samples in the logistically-mapped space of shape [no_samples, self.no_params]
+            Flow samples in the logistically-mapped space of shape [no_samples, Nparams]
         """
         samples = np.zeros((no_samples, self.no_params))
 
+        #check that requested conditional are the same shape as Nhyperparameters
+        if conditional.astype(np.float32).shape != self.cond_inputs:
+            raise ValueError(f"Expected shape {self.cond_inputs} but got {conditional.astype(np.float32).shape}")
+
         with torch.no_grad():
             conditional = torch.from_numpy(conditional.astype(np.float32))
-            #tile as many conditional chi_b alpha pairs as no samples
+            #tile as many conditional hyperparameter values as no samples
             conditional = conditional.tile(no_samples,1)
             samples = self.network.sample(no_samples, conditional=conditional)
 
@@ -271,19 +274,15 @@ class NFlow():
             the corersponding sample weigths to the batch of training data
             of shape [no_samples]
         """
-        #batched samples found, depending on the number of conditional samples in each model
-        if self.cond_inputs >=2:
-            random_samples = np.random.choice(np.shape(training_samples)[0],size=(int(self.batch_size)))
-            batched_hp_pairs = training_samples[random_samples,-2:]
-            batch_weights = training_samples[random_samples,-3]
-        else:
-            random_samples = np.random.choice(np.shape(training_samples)[0],size=(int(self.batch_size)))
-            batched_hp_pairs = training_samples[random_samples, -1]
-            batch_weights = training_samples[random_samples,-2]
+        #retrieve random samples of size batch_size from training samples
+        random_sample_idxs = np.random.choice(np.shape(training_samples)[0],size=(int(self.batch_size)))
 
-        batched_samples = training_samples[random_samples,:(self.no_params)]
+        #retrieve dataspace samples, and corresponding hyperparameters and weights to the randomly drawn samples
+        batched_samples = training_samples[random_sample_idxs,:self.no_params]
+        batched_hp_pairs = training_samples[random_sample_idxs, self.no_params:self.cond_inputs]
+        batch_weights = training_samples[random_sample_idxs,-1]
 
-        #reshape tensors
+        #reshape tensors to be correct shape
         xdata=torch.from_numpy(batched_samples.astype(np.float32)).to(self.device)
         xhyperparams = torch.from_numpy(batched_hp_pairs.astype(np.float32)).to(self.device)
         xhyperparams = xhyperparams.reshape(-1,self.cond_inputs)
@@ -306,18 +305,15 @@ class NFlow():
             the corersponding sample weigths to the batch of validation data
             of shape [no_samples]
         """
-        
-        #find weights from validation data
-        if self.cond_inputs >=2:
-            val_weights = validation_data[:,-3]
-        else:
-            val_weights = validation_data[:,-2]
 
         #pull batch from data
         random_samples = np.random.choice(np.shape(validation_data)[0], size=(int(self.batch_size)))
-        val_weights = val_weights[random_samples]
-        validation_hp_pairs = validation_data[random_samples,-self.cond_inputs:]
-        validation_samples = validation_data[random_samples,:self.no_params]
+
+        #retrieve dataspace samples, and corresponding hyperparameters and weights to the randomly drawn samples
+        batched_samples = validation_data[random_sample_idxs,:self.no_params]
+        batched_hp_pairs = validation_data[random_sample_idxs, self.no_params:self.cond_inputs]
+        batch_weights = validation_data[random_sample_idxs,-1]
+
         #reshape
         xval=torch.from_numpy(validation_samples.astype(np.float32)).to(self.device)
         xhyperparams = torch.from_numpy(validation_hp_pairs.astype(np.float32)).to(self.device)
@@ -342,16 +338,15 @@ class NFlow():
         #dtheta prime by dtheta
         jac = torch.zeros(sample.shape[0], self.no_params).to(self.device)
 
-        jac[:,0] = mappings[1]/((sample[:,0])*(mappings[1]-(sample[:,0]))*mappings[0])
-        jac[:,1] = mappings[3]/((sample[:,1])*(mappings[3]-(sample[:,1]))*mappings[2])
-        jac[:,2] = 1/(1-sample[:,2]**2)
-        jac[:,3] = mappings[5]/((sample[:,3])*(mappings[5]-(sample[:,3]))*mappings[4])
+        #loop over number of params and add jacobian term, assuming all dimensions have undergone a logistic mapping
+        for i in range(self.no_params):
+            jac[:,i] = mappings[i+1]/((sample[:,i])*(mappings[i+1]-(sample[:,i]))*mappings[i])
         
         return torch.sum(torch.log(torch.abs(jac)), dim=1)
 
     def get_logprob(self, sample, mapped_sample, mappings, conditionals):
         """
-        get log_prob given a sample of [mchirp,q,chieff,z] given conditional hyperparameters
+        get log_prob p(theta|Lambda) given a sample of gw observables theta given conditional hyperparameters Lambda
 
         Parameters
         ----------
@@ -362,7 +357,7 @@ class NFlow():
             posterior samples mapped into logistic space with Nflow.map_obs function
             [Nobs x Nsamples x Nparams] shape array
         conditionals : array
-            values of hyperparameters chi_b and alpha_CE
+            values of population hyperparameters
             [Nobs x Nsamples x Nconditionals] shapped array
 
         Returns
@@ -396,8 +391,8 @@ class NFlow():
 
             log_prob = log_prob.cpu().numpy() 
             if np.any(np.isnan(log_prob)):
-                print('nans!')
-            log_prob[np.isnan(log_prob)] = -np.inf
+                sys.exit('Unexpected nans in log prob evaluation, quitting code.')
+                log_prob[np.isnan(log_prob)] = -np.inf
 
         return log_prob
 

--- a/sample/sample.py
+++ b/sample/sample.py
@@ -246,7 +246,7 @@ def lnlike_cont(x, data, pop_models, submodels_dict, channels, prior_pdf, smalle
     alpha = 0
 
     #find log of alpha_CE for finding likelihood
-    model_hyperparams = [x[0],np.log(x[1])]
+    model_hyperparams = x[:len(submodels_dict)]
 
     # Iterate over channels in this submodel, return likelihood of population model
     for channel, beta in zip(channels, betas):
@@ -254,7 +254,7 @@ def lnlike_cont(x, data, pop_models, submodels_dict, channels, prior_pdf, smalle
         smdl = pop_models[channel]
         #sum likelihood over channels, keep track of detection efficiency
         lnprob = logsumexp([lnprob, np.log(beta) + smdl(data, model_hyperparams[:smdl.conditionals], smallest_N, prior_pdf=prior_pdf)], axis=0)
-        alpha += beta * smdl.get_alpha([model_hyperparams[:smdl.conditionals]])
+        alpha += beta * smdl.get_alpha(model_hyperparams[:smdl.conditionals])
 
     #returns lnprob summed over events (probability multiplied over events, divided by detection efficiency)
     return (lnprob-np.log(alpha)).sum()
@@ -288,6 +288,7 @@ def lnlike_disc(x, data, pop_models, submodels_dict, channels, prior_pdf, use_fl
         log likelihood summed over events, accounting for detection efficiency
     """
     model_list = []
+    #find hyperparameter index of walker
     hyperparam_idxs = []
     for hyper_idx in list(submodels_dict.keys()):
         hyperparam_idxs.append(int(np.floor(x[hyper_idx])))
@@ -313,17 +314,14 @@ def lnlike_disc(x, data, pop_models, submodels_dict, channels, prior_pdf, use_fl
         #calls popModels to return likelihood of data given model and add contribution from this channel
         if use_flows==True:
             smdl = pop_models[channel]
-            #LSE over channels
-            #keep lnprob as shape [Nobs]
+            #identify submodel conditional values
             conditional_hps = [smdl.hps[i][hyperparam_idxs[i]] for i in range(smdl.conditionals)]
-            if len(conditional_hps) >1:
-                conditional_hps = [conditional_hps[0],np.log(conditional_hps[1])]
+            #LSE over channels
             lnprob = logsumexp([lnprob, np.log(beta) + smdl(data, conditional_hps, smallest_N, prior_pdf=prior_pdf)], axis=0)
-            #for CE alpha dictionary key is tuple, but for non-CE, keys are ints
-            if channel == 'CE':
-                alpha += beta * smdl.alpha[tuple(hyperparam_idxs)]
-            else:
-                alpha += beta * smdl.alpha[hyperparam_idxs[0]]
+            #for multiple hyperparameters, dictionary key is tuple, but for single hyperparameters, keys are ints
+            if hyperparam_idxs.ndim > 0:
+                hyperparam_idxs = tuple(hyperparam_idxs)
+            alpha += beta * smdl.alpha[hyperparam_idxs]
         else:
             smdl = reduce(operator.getitem, model_list_tmp, pop_models) #grabs correct submodel
             lnprob = logsumexp([lnprob, np.log(beta) + np.log(smdl(data, smallest_N))], axis=0)


### PR DESCRIPTION
- The flows code should now handle different numbers of hyperparameter dimensions, without hardcoding for the CE channel
- This still needs some testing for evaluating the flows. There is a bug with the samples mapping - as the jacobian calculation assumes all dimensions are mapped with logistic mapping - not accounting for parameters with 'transf':'tanh'.
- As inputs to `bbh_models.get_models`, and within the flows class, we require dictionaries for the hyperparameters (`full_hyperparam_dict`, with expected structure the same as [here](https://chat.ligo.org/ligo/pl/trhf91fm9i8i5kao14s7q4tgcy)) and event parameters (`param_dict`, with expected structure `param_dict = {'mchirp':{'bounds':(0,100.), 'transf':'logit'}, 'q':{'bounds':(0,1.), 'transf':'logit'}, 'chieff':{'bounds':(-1.,1.), 'transf':'tanh'}, 'z':{'bounds':(0.,10.), 'transf':'logit'}}` for the flows - 'transf' isn't a required key for the KDEs)
- I haven't made the necessary changes to implement these dictionaries in `model_select`, and the arguments passed to `bbh_models.get_models` in `model_select` are no longer correct, as they do not include the dictionaries above. 
- Initialising the KDEs within `bbh_models.get_models` still uses the deepest models identified from the keys in the samples hdf5 file, so this should still work, but probably should be updated to just use the keys specified in `full_hyperparam_dict`.