### PR TITLE
Typo/Jacobian fixes for removing hardcoded hyperparameter structures

### DIFF
--- a/model_select
+++ b/model_select
@@ -356,7 +356,7 @@ if use_flows==True:
                 pop_models[channel].wandb_init(int(args.epochs[i]))
             else:
                 pop_models[channel].train(int(args.no_trans[i]), int(args.spline_bins[i]), int(args.no_neurons[i]), lr[i], \
-                    int(args.epochs[i]), args.batch_no, args.flow_model_filename, devicee=args.device)
+                    int(args.epochs[i]), args.batch_no, args.flow_model_filename, device=args.device)
         else:
             pop_models[channel].load_model(args.flow_model_filename, device=args.device)
 else:

--- a/populations/Pop_Flows.py
+++ b/populations/Pop_Flows.py
@@ -351,7 +351,7 @@ class FlowModel(Model):
         conditionals = np.repeat([conditionals],np.shape(mapped_obs)[0], axis=0)
 
         #calculates likelihoods for all events and all samples
-        likelihoods_per_samp = self.flow.get_logprob(data, mapped_obs, self.mappings, conditionals)
+        likelihoods_per_samp = self.flow.get_logprob(data, mapped_obs, self.param_dict, conditionals)
 
         if smallest_N is not None:
             #LSE population probability plus uniform regularisation
@@ -421,12 +421,12 @@ class FlowModel(Model):
         #compute logistic mappings of data
         for pidx, param in enumerate(self.param_dict):
             if self.param_dict[param]['transf'] == 'logit':
-                mapped_data[:,:,pidx] = self.logistic(data[:,:,pidx], False, self.param_dict[param]['logit_max'], self.param_dict[param]['max'])
+                mapped_data[:,:,pidx],_,_ = self.logistic(data[:,:,pidx], False, self.param_dict[param]['logit_max'], self.param_dict[param]['max'])
             elif self.param_dict[param]['transf'] == 'tanh':
                 mapped_data[:,:,pidx] = np.arctanh(data[:,:,pidx])
             else:
                 print(f'No transformation type specified for {param} dimension, attempting logistic transform')
-                mapped_data[:,:,pidx] = self.logistic(data[:,:,pidx], False, self.param_dict[param]['logit_max'], self.param_dict[param]['max'])
+                mapped_data[:,:,pidx],_,_ = self.logistic(data[:,:,pidx], False, self.param_dict[param]['logit_max'], self.param_dict[param]['max'])
 
         return mapped_data
 

--- a/populations/utils/flow.py
+++ b/populations/utils/flow.py
@@ -322,7 +322,7 @@ class NFlow():
         self.network.load_state_dict(torch.load(filename, map_location=torch.device(self.device)))
         self.network.eval()
 
-    def log_jacobian(self,sample, mappings):
+    def log_jacobian(self,sample, param_dict):
         """
         Calculate the log jacobian term to add to the log likelihood to account for the logistic transforms
         of the samples of [mchirp, q, chieff, z]
@@ -332,13 +332,19 @@ class NFlow():
         #dtheta prime by dtheta
         jac = torch.zeros(sample.shape[0], self.no_params).to(self.device)
 
-        #loop over number of params and add jacobian term, assuming all dimensions have undergone a logistic mapping
-        for i in range(self.no_params):
-            jac[:,i] = mappings[i+1]/((sample[:,i])*(mappings[i+1]-(sample[:,i]))*mappings[i])
-        
+        #loop over number of params and add jacobian term, according to the type of transformation specified for that dimension
+        for i, param in enumerate(param_dict):
+            if param_dict[param]['transf'] == 'logit':
+                jac[:,i] = param_dict[param]['max']/((sample[:,i])*(param_dict[param]['max']-(sample[:,i]))*param_dict[param]['logit_max'])
+            elif param_dict[param]['transf'] == 'tanh':
+                jac[:,i] = 1/(1-sample[:,i]**2)
+            else:
+                print(f'No transformation type specified for {param} dimension, attempting jacobian calculate for logistic transform')
+                jac[:,i] = param_dict[param]['max']/((sample[:,i])*(param_dict[param]['max']-(sample[:,i]))*param_dict[param]['logit_max'])
+            
         return torch.sum(torch.log(torch.abs(jac)), dim=1)
 
-    def get_logprob(self, sample, mapped_sample, mappings, conditionals):
+    def get_logprob(self, sample, mapped_sample, param_dict, conditionals):
         """
         get log_prob p(theta|Lambda) given a sample of gw observables theta given conditional hyperparameters Lambda
 
@@ -378,7 +384,7 @@ class NFlow():
 
         with torch.no_grad():
             log_prob = self.network.log_prob(mapped_sample, hyperparams)
-            log_prob += self.log_jacobian(sample, mappings)
+            log_prob += self.log_jacobian(sample, param_dict)
 
             #reshape
             log_prob = torch.reshape(log_prob, [shape[0],shape[1]])

--- a/sample/sample.py
+++ b/sample/sample.py
@@ -315,12 +315,14 @@ def lnlike_disc(x, data, pop_models, submodels_dict, channels, prior_pdf, use_fl
         if use_flows==True:
             smdl = pop_models[channel]
             #identify submodel conditional values
-            conditional_hps = [smdl.hps[i][hyperparam_idxs[i]] for i in range(smdl.conditionals)]
+            conditional_hps = [smdl.hp_vals[i][hyperparam_idxs[i]] for i in range(smdl.conditionals)]
             #LSE over channels
             lnprob = logsumexp([lnprob, np.log(beta) + smdl(data, conditional_hps, smallest_N, prior_pdf=prior_pdf)], axis=0)
             #for multiple hyperparameters, dictionary key is tuple, but for single hyperparameters, keys are ints
-            if hyperparam_idxs.ndim > 0:
+            if smdl.conditionals > 1:
                 hyperparam_idxs = tuple(hyperparam_idxs)
+            else:
+                hyperparam_idxs = hyperparam_idxs[0]
             alpha += beta * smdl.alpha[hyperparam_idxs]
         else:
             smdl = reduce(operator.getitem, model_list_tmp, pop_models) #grabs correct submodel


### PR DESCRIPTION
Addresses some bugs and typos that were missing from https://github.com/michaelzevin/AMAZE/pull/10:

- Typo in `device` argument in `model_select` fixed (https://github.com/michaelzevin/AMAZE/pull/10#discussion_r2040267414)
- The calculation of the Jacobian in `flow.py` is now passed the mappings in the form of `param_dict`, and can handle tanh transformation as well as logistic transformations for the training data mappings.
- Likelihood calls in `sample.py` now updated to work with the renamed hyperparameter values and correctly call the detection efficiency based on the number of conditionals for that channel/flow.

These changes fix the bugs I found in initial testing of evaluating the flows given the changes made in https://github.com/michaelzevin/AMAZE/pull/10, which involved calling the `lnlike_cont` and `lnlike_disc` functions in `sample.py`. I have not yet run `model_select` in full to test this.