### PR TITLE
Add random seed to detection efficiency calculation

### DIFF
--- a/amaze
+++ b/amaze
@@ -57,6 +57,7 @@ def amaze(ini_file):
                 param_dict = settings['event-parameter-dict'], \
                 hyperparam_dict = settings['population-parameter-dict'], \
                 use_flows = settings['use-flows'], \
+                random_seed = settings['random-seed'] \
                 sensitivity=settings['sensitivity-key'], \
                 spinmag=settings['spin-mag-distribution'], \
                 max_samps=settings['kde-max-samples'], \

--- a/amaze
+++ b/amaze
@@ -40,6 +40,9 @@ def amaze(ini_file):
     # --- Set random seed
     if settings['random-seed']:
         np.random.seed(settings['random-seed'])
+        random_seed = settings['random-seed']
+    else:
+        random_seed = None
 
     # --- Set verbosity
     verbose = settings['verbose']
@@ -57,7 +60,7 @@ def amaze(ini_file):
                 param_dict = settings['event-parameter-dict'], \
                 hyperparam_dict = settings['population-parameter-dict'], \
                 use_flows = settings['use-flows'], \
-                random_seed = settings['random-seed'] \
+                random_seed = random_seed \
                 sensitivity=settings['sensitivity-key'], \
                 spinmag=settings['spin-mag-distribution'], \
                 max_samps=settings['kde-max-samples'], \

--- a/populations/Pop_Flows.py
+++ b/populations/Pop_Flows.py
@@ -52,7 +52,7 @@ class Model(object):
 
 class FlowModel(Model):
     @staticmethod
-    def from_samples(channel, samples, param_dict, channel_hyperparams, smdl_indxs_combos, sensitivity=None):
+    def from_samples(channel, samples, param_dict, channel_hyperparams, smdl_indxs_combos, random_seed, sensitivity=None):
         """
         Generate a normalising flow model instance from `samples`, where the keys in `params_dict` are a series in the `samples` dataframe. 
         
@@ -110,9 +110,9 @@ class FlowModel(Model):
             if sensitivity is not None:
                 # if cosmological weights are provided, do mock draws from the pop
                 if 'weight' in sbml_samps.keys():
-                    mock_samp = sbml_samps.sample(int(1e6), weights=(sbml_samps['weight']/len(sbml_samps)), replace=True)
+                    mock_samp = sbml_samps.sample(int(1e6), weights=(sbml_samps['weight']/len(sbml_samps)), replace=True, random_state=random_seed)
                 else:
-                    mock_samp = sbml_samps.sample(int(1e6), replace=True)
+                    mock_samp = sbml_samps.sample(int(1e6), replace=True, random_state=random_seed)
                 alpha[dict_key]=np.sum(mock_samp['pdet_'+sensitivity]) / len(mock_samp)
             else:
                 alpha[dict_key]=1.0

--- a/populations/models.py
+++ b/populations/models.py
@@ -130,7 +130,7 @@ def get_channel_smdls(chnl, deepest_models, hyperparam_pts_per_dim):
     return channel_smdls, smdl_indxs_combos
 
 def get_models(file_path, channel_dict, param_dict, \
-            hyperparam_dict, use_flows, \
+            hyperparam_dict, use_flows, random_seed, \
             sensitivity=None, **kwargs):
     """
     Call this to get all the models and submodels, as well
@@ -151,6 +151,8 @@ def get_models(file_path, channel_dict, param_dict, \
         discrete values (with value key)/full names as values
     use_flows : bool
         flag for whether to use KDEs or flows in inference
+    random_seed : int
+        random seed for the run to be passed to KDE and Flow models
     sensitivity : str
         key string of detection probabilities to use for determining detection efficiency
           'pdet_${sensitivity}' in the hdf5 file
@@ -195,6 +197,7 @@ def get_models(file_path, channel_dict, param_dict, \
                 param_dict, \
                 channel_hyperparams, \
                 smdl_indxs_combos, \
+                random_seed = random_seed, \
                 sensitivity=sensitivity)
         return deepest_models, flow_models
     #KDE case: reads in submodel for each of the deepest model and sends to KDEModel
@@ -217,6 +220,7 @@ def get_models(file_path, channel_dict, param_dict, \
                                 label=label, \
                                 samples=df, \
                                 param_dict=param_dict, \
+                                random_seed = random_seed, \
                                 sensitivity=sensitivity, \
                                 **kwargs)
                         current_level[part] = mdl


### PR DESCRIPTION
This ensures that the random samples used to calculate the detection efficiency are reproducable with the input random seed, for both flows and KDEs.